### PR TITLE
Fix metadata extraction failures for None serializers and OperandHold…

### DIFF
--- a/drf_to_mkdoc/utils/schema.py
+++ b/drf_to_mkdoc/utils/schema.py
@@ -10,9 +10,13 @@ from rest_framework.serializers import BaseSerializer, ListSerializer
 from rest_framework.viewsets import ViewSetMixin
 
 from drf_to_mkdoc.conf.settings import drf_to_mkdoc_settings
-from rest_framework.permissions import OperandHolder
 
 logger = logging.getLogger(__name__)
+
+try:
+    from rest_framework.permissions import OperandHolder
+except ImportError:
+    OperandHolder = None
 
 
 
@@ -92,9 +96,15 @@ class ViewMetadataExtractor:
             # Combine recursively extracted permissions
             return f"({left_perms}{op_symbol}{right_perms})"
         else:
-            # Regular permission class
+            # Regular permission class or instance
             try:
-                return f"{perm.__module__}.{perm.__name__}"
+                # Handle both permission classes and instances
+                if inspect.isclass(perm):
+                    return f"{perm.__module__}.{perm.__name__}"
+                else:
+                    # Permission instance
+                    perm_class = perm.__class__
+                    return f"{perm_class.__module__}.{perm_class.__name__}"
             except (AttributeError, TypeError):
                 # Fallback for unexpected types
                 return str(perm)

--- a/drf_to_mkdoc/utils/schema.py
+++ b/drf_to_mkdoc/utils/schema.py
@@ -64,42 +64,33 @@ class ViewMetadataExtractor:
             )
             return str(perm)
         
-        # Try isinstance check first if OperandHolder is available, otherwise use attribute-based detection
-        # Also verify that required attributes exist (defensive check for different DRF versions)
-        # Check for common attribute name variations across DRF versions
+        # Detect OperandHolder: use isinstance if available, otherwise check for operator_class, op1_class, op2_class
         if OperandHolder is not None:
-            is_operand_holder = isinstance(perm, OperandHolder) and (
-                (hasattr(perm, 'op1') and hasattr(perm, 'op2')) or
-                (hasattr(perm, 'left') and hasattr(perm, 'right')) or
-                (hasattr(perm, 'operand1') and hasattr(perm, 'operand2'))
-            )
+            is_operand_holder = isinstance(perm, OperandHolder)
         else:
-            # OperandHolder from DRF has op1, op2, and operator_class attributes
-            # Check for common attribute name variations
+            # OperandHolder from DRF has operator_class, op1_class, and op2_class attributes
             is_operand_holder = (
-                ((hasattr(perm, 'op1') and hasattr(perm, 'op2')) or
-                 (hasattr(perm, 'left') and hasattr(perm, 'right')) or
-                 (hasattr(perm, 'operand1') and hasattr(perm, 'operand2')))
-                and hasattr(perm, 'operator_class')
+                hasattr(perm, 'operator_class')
+                and hasattr(perm, 'op1_class')
+                and hasattr(perm, 'op2_class')
             )
         
         if is_operand_holder:
-            # This is an OperandHolder - recursively extract left and right permissions
-            # Use getattr with safe defaults in case attributes are missing
-            # Try common attribute names used by OperandHolder in different DRF versions
-            op1 = getattr(perm, 'op1', None) or getattr(perm, 'left', None) or getattr(perm, 'operand1', None)
-            op2 = getattr(perm, 'op2', None) or getattr(perm, 'right', None) or getattr(perm, 'operand2', None)
+            # This is an OperandHolder - extract operand classes (op1_class, op2_class)
+            op1_class = getattr(perm, 'op1_class', None)
+            op2_class = getattr(perm, 'op2_class', None)
             
-            if op1 is None or op2 is None:
-                # OperandHolder detected but missing required attributes - fallback
+            if op1_class is None or op2_class is None:
+                # OperandHolder detected but missing required class attributes - fallback
                 logger.warning(
-                    f"OperandHolder detected but missing operand attributes (tried op1/op2, left/right, operand1/operand2). "
+                    f"OperandHolder detected but missing op1_class or op2_class attributes. "
                     f"Falling back to string representation. Object: {perm}"
                 )
                 return str(perm)
             
-            left_perms = self._extract_permission_recursive(op1, depth + 1, max_depth)
-            right_perms = self._extract_permission_recursive(op2, depth + 1, max_depth)
+            # Recursively process the permission classes
+            left_perms = self._extract_permission_recursive(op1_class, depth + 1, max_depth)
+            right_perms = self._extract_permission_recursive(op2_class, depth + 1, max_depth)
             
             # Determine the operator symbol from operator_class or op attribute
             if hasattr(perm, 'operator_class'):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly resolve complex, nested permission combinations (including guarded recursion) so displayed permission requirements are accurate.
  * Safely handle missing optional permission helper to avoid failures when that component is absent.
  * Prevent errors for endpoints without serializers (e.g., file downloads) by skipping undefined serializer metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->