### PR TITLE
Add empty state and hide the app name when there is not any endpoint …

### DIFF
--- a/drf_to_mkdoc/static/drf-to-mkdoc/javascripts/endpoints-filter.js
+++ b/drf_to_mkdoc/static/drf-to-mkdoc/javascripts/endpoints-filter.js
@@ -49,11 +49,17 @@ function applyFilters() {
         section.style.display = visibleCards.length === 0 ? 'none' : '';
     });
 
-    // Collapse app sections with no visible viewsets
+    // Collapse app sections with no visible cards
     document.querySelectorAll('.app-section').forEach(app => {
-        const visibleViewsets = app.querySelectorAll('.viewset-section:not([style*="display: none"])');
-        app.style.display = visibleViewsets.length === 0 ? 'none' : '';
+        const visibleCards = app.querySelectorAll('.endpoint-card:not(.hidden)');
+        app.style.display = visibleCards.length === 0 ? 'none' : '';
     });
+
+    // Show/hide empty state
+    const emptyState = document.getElementById('empty-state');
+    if (emptyState) {
+        emptyState.style.display = visibleCount === 0 ? 'block' : 'none';
+    }
 
     // Update filter result stats
     document.querySelector('.filter-results').textContent =

--- a/drf_to_mkdoc/static/drf-to-mkdoc/stylesheets/endpoints/endpoints-grid.css
+++ b/drf_to_mkdoc/static/drf-to-mkdoc/stylesheets/endpoints/endpoints-grid.css
@@ -249,6 +249,11 @@
     transform: translateY(0);
 }
 
+.empty-state-button:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 3px;
+}
+
 @keyframes pulse {
     0%, 100% {
         opacity: 0.6;

--- a/drf_to_mkdoc/static/drf-to-mkdoc/stylesheets/endpoints/endpoints-grid.css
+++ b/drf_to_mkdoc/static/drf-to-mkdoc/stylesheets/endpoints/endpoints-grid.css
@@ -192,3 +192,70 @@
 .model-card:nth-child(4) { animation-delay: 0.4s; }
 .model-card:nth-child(5) { animation-delay: 0.5s; }
 .model-card:nth-child(6) { animation-delay: 0.6s; }
+
+/* ===== EMPTY STATE ===== */
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    text-align: center;
+    margin: 40px 0;
+    animation: fadeInUp 0.5s ease-out;
+}
+
+.empty-state-icon {
+    font-size: 64px;
+    margin-bottom: 24px;
+    opacity: 0.6;
+    animation: pulse 2s ease-in-out infinite;
+}
+
+.empty-state-title {
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 12px 0;
+}
+
+.empty-state-message {
+    font-size: 16px;
+    color: var(--text-secondary);
+    margin: 0 0 24px 0;
+    max-width: 400px;
+}
+
+.empty-state-button {
+    padding: 12px 24px;
+    background: var(--accent-primary);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition-normal);
+    box-shadow: var(--shadow);
+}
+
+.empty-state-button:hover {
+    background: var(--accent-hover);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-hover);
+}
+
+.empty-state-button:active {
+    transform: translateY(0);
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 0.6;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.8;
+        transform: scale(1.05);
+    }
+}

--- a/drf_to_mkdoc/templates/endpoints/list/base.html
+++ b/drf_to_mkdoc/templates/endpoints/list/base.html
@@ -13,10 +13,10 @@
 <div class="main-content">
     {% include "endpoints/list/filter_section.html" %}
     {% include "endpoints/list/settings_modal.html" %}
-    <div class="empty-state" id="empty-state" style="display: none;">
-        <div class="empty-state-icon">🔍</div>
+    <div class="empty-state" id="empty-state" style="display: none;" role="status" aria-live="polite">
+        <div class="empty-state-icon" aria-hidden="true">🔍</div>
         <h3 class="empty-state-title">No endpoints found</h3>
-        <button class="empty-state-button" onclick="clearFilters()">Clear all filters</button>
+        <button class="empty-state-button" onclick="clearFilters()" aria-label="Clear all filters to show all endpoints">Clear all filters</button>
     </div>
     {% for app_name, endpoints in endpoints_by_app.items %}
         <div class="app-section">

--- a/drf_to_mkdoc/templates/endpoints/list/base.html
+++ b/drf_to_mkdoc/templates/endpoints/list/base.html
@@ -13,12 +13,19 @@
 <div class="main-content">
     {% include "endpoints/list/filter_section.html" %}
     {% include "endpoints/list/settings_modal.html" %}
+    <div class="empty-state" id="empty-state" style="display: none;">
+        <div class="empty-state-icon">🔍</div>
+        <h3 class="empty-state-title">No endpoints found</h3>
+        <button class="empty-state-button" onclick="clearFilters()">Clear all filters</button>
+    </div>
     {% for app_name, endpoints in endpoints_by_app.items %}
-        <h2>{{ app_name|title }}</h2>
-        <div class="endpoints-grid">
-            {% for endpoint in endpoints %}
-                {% include "endpoints/list/endpoint_card.html" %}
-            {% endfor %}
+        <div class="app-section">
+            <h2>{{ app_name|title }}</h2>
+            <div class="endpoints-grid">
+                {% for endpoint in endpoints %}
+                    {% include "endpoints/list/endpoint_card.html" %}
+                {% endfor %}
+            </div>
         </div>
     {% endfor %}
 </div>

--- a/drf_to_mkdoc/utils/endpoint_detail_generator.py
+++ b/drf_to_mkdoc/utils/endpoint_detail_generator.py
@@ -682,6 +682,9 @@ def _prepare_response_data(operation_id: str, responses: dict, components: dict)
         
         # Check if this is a 200 response with no meaningful data
         if status_code == "200" and _is_empty_response(schema, examples):
+            logger.debug(
+                f"Converting empty 200 response to 204 No Content for operation {operation_id}"
+            )
             # Convert to 204 No Content
             formatted_response = {
                 "status_code": "204",


### PR DESCRIPTION
…after search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an empty-state display when no endpoints match filters, including icon, message, and a Clear filters action.
  * App sections now automatically hide when they contain no visible endpoint cards.

* **Bug Fixes**
  * Improved response handling to detect empty responses and treat them as no-content (204) where appropriate, improving status categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->